### PR TITLE
feat: quick addition of 'cur' and 'short' options

### DIFF
--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1,6 +1,7 @@
 type Type = "Residential" | "Wireless" | "Business" | "Hosting" | "TOR" | "SOCKS" | "SOCKS4" | "SOCKS4A" | "SOCKS5" | "SOCKS5H" | "Shadowsocks" | "HTTP" | "HTTPS" | "Compromised Server" | "Inference Engine" | "OpenVPN" | "VPN" | "whitelisted by x" | "blacklisted by x";
 type Status = "ok" | "warning" | "denied" | "error";
 type IPAddressInfo = {
+    ip?: string;
     asn: string;
     provider: string;
     organisation: string;
@@ -14,7 +15,7 @@ type IPAddressInfo = {
     city: string;
     latitude: number;
     longitude: number;
-    currency: {
+    currency?: {
         code: string;
         name: string;
         symbol: string;
@@ -28,9 +29,9 @@ type ProxyCheckResponse = {
     status: Status;
     node?: string;
     query_time?: string;
-} & {
+} & ({
     [ipAddress: string]: IPAddressInfo;
-};
+} | IPAddressInfo);
 interface ProxyCheckConstructor {
     api_key: string;
 }
@@ -45,6 +46,8 @@ interface ProxyCheckOptions {
     seen?: 0 | 1;
     days?: number;
     tag?: string;
+    cur?: 0 | 1;
+    short?: 0 | 1;
 }
 interface ProxyCheckGetUsageReturn {
     error?: string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,7 @@
 type Type = "Residential" | "Wireless" | "Business" | "Hosting" | "TOR" | "SOCKS" | "SOCKS4" | "SOCKS4A" | "SOCKS5" | "SOCKS5H" | "Shadowsocks" | "HTTP" | "HTTPS" | "Compromised Server" | "Inference Engine" | "OpenVPN" | "VPN" | "whitelisted by x" | "blacklisted by x";
 type Status = "ok" | "warning" | "denied" | "error";
 type IPAddressInfo = {
+    ip?: string;
     asn: string;
     provider: string;
     organisation: string;
@@ -14,7 +15,7 @@ type IPAddressInfo = {
     city: string;
     latitude: number;
     longitude: number;
-    currency: {
+    currency?: {
         code: string;
         name: string;
         symbol: string;
@@ -28,9 +29,9 @@ type ProxyCheckResponse = {
     status: Status;
     node?: string;
     query_time?: string;
-} & {
+} & ({
     [ipAddress: string]: IPAddressInfo;
-};
+} | IPAddressInfo);
 interface ProxyCheckConstructor {
     api_key: string;
 }
@@ -45,6 +46,8 @@ interface ProxyCheckOptions {
     seen?: 0 | 1;
     days?: number;
     tag?: string;
+    cur?: 0 | 1;
+    short?: 0 | 1;
 }
 interface ProxyCheckGetUsageReturn {
     error?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxycheck-ts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "ProxyCheck.io API Client",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ type Type =
 type Status = "ok" | "warning" | "denied" | "error"
 
 export type IPAddressInfo = {
+  ip?: string
   asn: string
   provider: string
   organisation: string
@@ -37,7 +38,7 @@ export type IPAddressInfo = {
   city: string
   latitude: number
   longitude: number
-  currency: {
+  currency?: {
     code: string
     name: string
     symbol: string
@@ -52,9 +53,12 @@ export type ProxyCheckResponse = {
   status: Status
   node?: string
   query_time?: string
-} & {
-  [ipAddress: string]: IPAddressInfo
-}
+} & (
+  | {
+      [ipAddress: string]: IPAddressInfo
+    }
+  | IPAddressInfo
+)
 
 interface ProxyCheckConstructor {
   api_key: string
@@ -71,6 +75,8 @@ interface ProxyCheckOptions {
   seen?: 0 | 1
   days?: number
   tag?: string
+  cur?: 0 | 1
+  short?: 0 | 1
 }
 
 interface ProxyCheckGetUsageReturn {


### PR DESCRIPTION
Allow the usage of 

- cur?: 0 | 1;
> When the asn flag is enabled you'll receive a currency result by default, you can choose to disable this by supplying &cur=0, please note that &cur=1 will not activate the currency display unless &asn=1 is also supplied.

- short?: 0 | 1;
> When the short flag is set to 1 we will compress the result, placing the IP address you're testing in the same array as the results instead of a sub-array under the IP address heading. This can make the API easier to parse in some languages but will lock you into only checking a single address per individual request.

Descriptions from the official api - https://proxycheck.io/api/